### PR TITLE
Avoid poison by checking for NaNs before fptosi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 on:
   push:
+    branches: [ master ]
   pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   linux-unittest:

--- a/lleaves/compiler/codegen/codegen.py
+++ b/lleaves/compiler/codegen/codegen.py
@@ -16,10 +16,12 @@ DOUBLE_PTR = ir.PointerType(DOUBLE)
 
 
 def iconst(value):
+    assert -(2**31) <= value <= 2**31 - 1
     return ir.Constant(INT, value)
 
 
 def lconst(value):
+    assert -(2**63) <= value <= 2**63 - 1
     return ir.Constant(LONG, value)
 
 
@@ -343,8 +345,8 @@ def _populate_categorical_node_block(
     """Populate block with IR for categorical node"""
     val = func.args[node.split_feature]
 
-    # For categoricals, processing NaNs happens through casting them via fptosi in the Forest root
-    # NaNs become negative max_val, which never exists in the Bitset, so they always go right
+    # For categoricals, processing NaNs happens in the Forest root, by explicitly checking for them
+    # NaNs are converted to negative max_val, which never exists in the Bitset, so they always go right
 
     # Find in bitset
     # First, check value > max categorical


### PR DESCRIPTION
closes #17 

Todos:
- [x] Check for generated x86 ASM differences
- [ ] Performance degradation on x86?