### PR TITLE
Add support to pass model definition as a str

### DIFF
--- a/lleaves/compiler/ast/parser.py
+++ b/lleaves/compiler/ast/parser.py
@@ -92,8 +92,8 @@ def _parse_tree_to_ast(tree_struct, features, class_id):
         return Tree(tree_struct["Tree"], leaves[0], features, class_id)
 
 
-def parse_to_ast(model_path):
-    scanned_model = scan_model_file(model_path)
+def parse_to_ast(model_str):
+    scanned_model = scan_model_file(model_str)
 
     n_args = scanned_model["general_info"]["max_feature_idx"] + 1
     n_classes = scanned_model["general_info"]["num_class"]

--- a/lleaves/compiler/ast/scanner.py
+++ b/lleaves/compiler/ast/scanner.py
@@ -34,7 +34,7 @@ def scan_model_file(model_str, general_info_only=False):
     general_info_block = next(blocks)
     assert general_info_block[0] == "tree" and general_info_block[1].startswith(
         "version="
-    ), f"supplied model is not a valid LightGBM model definition"
+    ), "supplied model is not a valid LightGBM model definition"
     res["general_info"] = _scan_block(general_info_block, INPUT_SCAN_KEYS)
     if general_info_only:
         return res

--- a/lleaves/compiler/tree_compiler.py
+++ b/lleaves/compiler/tree_compiler.py
@@ -8,13 +8,14 @@ from lleaves.compiler.codegen import gen_forest
 
 
 def compile_to_module(
-    file_path,
+    model_str,
+    model_name=None,
     fblocksize=34,
     finline=True,
     raw_score=False,
     froot_func_name="forest_root",
 ):
-    forest = parse_to_ast(file_path)
+    forest = parse_to_ast(model_str)
     forest.raw_score = raw_score
 
     ir = llvmlite.ir.Module(name="forest")
@@ -22,7 +23,7 @@ def compile_to_module(
 
     ir.triple = llvm.get_process_triple()
     module = llvm.parse_assembly(str(ir))
-    module.name = str(file_path)
+    module.name = model_name or "model.txt"
     module.verify()
 
     if os.environ.get("LLEAVES_PRINT_UNOPTIMIZED_IR") == "1":

--- a/lleaves/lleaves.py
+++ b/lleaves/lleaves.py
@@ -26,7 +26,7 @@ ENTRY_FUNC_TYPE = CFUNCTYPE(
 
 
 def _read(file):
-    with open(file, "r") as fp:
+    with open(file) as fp:
         return fp.read()
 
 


### PR DESCRIPTION
Presently, lleaves only supports passing model definitions as files, but in our use-case we store the model definitions in S3, which requires us to copy the definition to the local machine before loading and compiling. Rather than require this additional copy, this PR updates the code to support either passing a `model_file`, or passing the string content of that file directly as `model_str`.

If there's concern about the size of the string in memory, or there's a desire to accept broader stream formats I'd be happy to update the PR to take a `StringIO` at the top level instead of a `str`.
