### PR TITLE
Fix support for models with custom objective functions (Issue #92)

### DIFF
--- a/lleaves/compiler/ast/parser.py
+++ b/lleaves/compiler/ast/parser.py
@@ -98,9 +98,14 @@ def parse_to_ast(model_path):
     n_args = scanned_model["general_info"]["max_feature_idx"] + 1
     n_classes = scanned_model["general_info"]["num_class"]
     assert n_classes == scanned_model["general_info"]["num_tree_per_iteration"]
-    objective = scanned_model["general_info"]["objective"]
-    objective_func = objective[0]
-    objective_func_config = objective[1] if len(objective) > 1 else None
+    objective = scanned_model["general_info"].get("objective")
+    if objective:
+        objective_func = objective[0]
+        objective_func_config = objective[1] if len(objective) > 1 else None
+    else:
+        # Handle custom objective where objective is not specified
+        objective_func = None
+        objective_func_config = None
     average_output = "average_output" in scanned_model["general_info"]
     features = [
         Feature(is_categorical_feature(x))

--- a/lleaves/compiler/ast/scanner.py
+++ b/lleaves/compiler/ast/scanner.py
@@ -75,7 +75,7 @@ INPUT_SCAN_KEYS = {
     "num_tree_per_iteration": ScannedValue(int),
     "version": ScannedValue(str),
     "feature_infos": ScannedValue(str, True),
-    "objective": ScannedValue(str, True),
+    "objective": ScannedValue(str, True, null_ok=True),
     "average_output": ScannedValue(bool, null_ok=True),
 }
 TREE_SCAN_KEYS = {

--- a/tests/test_objective_functions.py
+++ b/tests/test_objective_functions.py
@@ -1,3 +1,5 @@
+import tempfile
+import os
 import lightgbm as lgb
 import numpy as np
 import pytest
@@ -40,6 +42,35 @@ def test_all_obj_funcs(modified_model_txt):
     llvm_model.compile()
     lgbm_model = lgb.Booster(model_file=modified_model_txt)
     np.testing.assert_almost_equal(lgbm_model.predict(data), llvm_model.predict(data))
+
+
+@pytest.fixture
+def custom_objective_model(tmp_path):
+    """Create a model file without the objective= line for testing Issue #92"""
+    model_filep = tmp_path / "custom_objective_model.txt"
+    with open("tests/models/leaf_scan/model.txt") as modelfile, open(
+        model_filep, "w"
+    ) as tmpfile:
+        for line in modelfile:
+            if not line.startswith("objective="):
+                tmpfile.write(line)
+    return str(model_filep)
+
+
+def test_custom_objective(custom_objective_model):
+    """Test that models with custom objectives (no objective= line) work - Issue #92"""
+    # Before our fix, this would raise: RuntimeError: Missing non-nullable keys {'objective'}
+    llvm_model = Model(model_file=custom_objective_model)
+    llvm_model.compile()
+    
+    # Test that the model can make predictions
+    data = np.array([[0.5], [-1.0], [2.0], [-3.0]])
+    predictions = llvm_model.predict(data)
+    
+    # Assertions
+    assert len(predictions) == len(data)
+    # Basic smoke test - predictions should be reasonable values
+    assert all(abs(p) < 10.0 for p in predictions)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #92

## Summary
- Adds support for models with custom objective functions where the `objective=` line is missing from the model file
- Makes the 'objective' key nullable in the scanner
- Properly handles missing objectives in the parser

## Changes Made
1. Updated `lleaves/compiler/ast/scanner.py` to make the 'objective' key nullable by adding `null_ok=True`
2. Modified `lleaves/compiler/ast/parser.py` to handle cases where the objective is not present in the scanned model  
3. Added test case `test_custom_objective` to verify custom objective support

## Test plan
- [x] Added test for custom objective model
- [ ] Run existing test suite to ensure no regressions
- [ ] Verify fix with user's actual custom objective model

🤖 Generated with [Claude Code](https://claude.ai/code)