### PR TITLE
Fix llvmlite 0.45+ compatibility

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   # runtime deps
   - python>=3.7
-  - llvmlite>=0.36
+  - llvmlite>=0.45
   - numpy
   # testing
   - pytest

--- a/lleaves/compiler/tree_compiler.py
+++ b/lleaves/compiler/tree_compiler.py
@@ -29,20 +29,30 @@ def compile_to_module(
     if os.environ.get("LLEAVES_PRINT_UNOPTIMIZED_IR") == "1":
         print(module)
 
-    # Create optimizer
-    pmb = llvm.PassManagerBuilder()
-    pmb.opt_level = 3
+    # Create optimizer using New Pass Manager API (llvmlite >= 0.45)
+    # Initialization is automatic in llvmlite >= 0.45, but target/asmprinter init still needed
+    llvm.initialize_native_target()
+    llvm.initialize_native_asmprinter()
 
+    target = llvm.Target.from_triple(llvm.get_process_triple())
+    try:
+        features = llvm.get_host_cpu_features().flatten()
+    except RuntimeError:
+        features = ""
+    target_machine = target.create_target_machine(
+        cpu=llvm.get_host_cpu_name(),
+        features=features,
+        reloc="pic",
+        codemodel="large",
+    )
+
+    pto = llvm.PipelineTuningOptions(speed_level=3, size_level=0)
     if finline:
-        # if inline_threshold is set LLVM inlines, precise value doesn't seem to matter
-        pmb.inlining_threshold = 1
+        pto.inlining_threshold = 1
 
-    pm_module = llvm.ModulePassManager()
-    # Add optimization passes to module-level optimizer
-    pmb.populate(pm_module)
-
-    # single pass only, compiler optimizations don't bring much speedup and take time
-    pm_module.run(module)
+    pb = llvm.PassBuilder(target_machine, pto)
+    pm_module = pb.getModulePassManager()
+    pm_module.run(module, pb)
 
     if os.environ.get("LLEAVES_PRINT_OPTIMIZED_IR") == "1":
         print(module)

--- a/lleaves/llvm_binding.py
+++ b/lleaves/llvm_binding.py
@@ -8,7 +8,7 @@ def _initialize_llvm():
     # this initializes the per-process LLVM state. It's save to call multiple times.
     # TODO we never call llvm.shutdown(), is this a problem?
     # some parts of the llvm memory are only deallocated once the process exits
-    llvm.initialize()
+    # Initialization is automatic in llvmlite >= 0.45, but target/asmprinter init still needed
     llvm.initialize_native_target()
     llvm.initialize_native_asmprinter()
 

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     python_requires=">=3.7",
-    install_requires=["llvmlite>=0.36", "numpy"],
+    install_requires=["llvmlite>=0.45", "numpy"],
 )


### PR DESCRIPTION
Fixes #95

## Summary
Migrates from the deprecated Legacy Pass Manager API to the New Pass Manager API to fix compatibility with llvmlite 0.45.0 and later versions.

## Changes
- Replaced `PassManagerBuilder` with `PipelineTuningOptions` and `PassBuilder`
- Removed deprecated `llvm.initialize()` call (automatic in llvmlite >= 0.45)
- Updated llvmlite requirement from `>=0.36` to `>=0.45`
- Updated both `setup.py` and `environment.yml`

## Technical Details
The Legacy Pass Manager was removed in llvmlite 0.45.0, causing:
```
AttributeError: module 'llvmlite.binding' has no attribute 'PassManagerBuilder'
```

The new implementation uses:
- `PipelineTuningOptions(speed_level=3, size_level=0)` for optimization configuration
- `PassBuilder` with target machine to create the module pass manager
- Updated `pm_module.run(module, pb)` signature

## Testing
All tests pass with llvmlite 0.45.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)